### PR TITLE
More fixes for the AccountUrlPattern

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1492,12 +1492,12 @@
         {
             new AuthenticatedFeed()
             {
-                AccountUrlPattern = @"^https:\/\/(?<account>[-a-zA-z0-9]+).pkgs.visualstudio.com",
+                AccountUrlPattern = @"^https:\/\/(?<account>[-a-zA-Z0-9]+)\.pkgs\.visualstudio\.com",
                 ProviderUrlTemplate = "https://{account}.pkgs.visualstudio.com/_apis/public/nuget/client/CredentialProviderBundle.zip"
             },
             new AuthenticatedFeed()
             {
-                AccountUrlPattern = @"^https:\/\/pkgs.dev.azure.com\/(?<account>[-a-zA-z0-9]+)\/",
+                AccountUrlPattern = @"^https:\/\/pkgs\.dev\.azure\.com\/(?<account>[-a-zA-Z0-9]+)\/",
                 ProviderUrlTemplate = "https://pkgs.dev.azure.com/{account}/_apis/public/nuget/client/CredentialProviderBundle.zip"
             }
         };


### PR DESCRIPTION
* Range for capitols was wrong and grabbing way too many characters.
* Dots for address were not escaped so accepted any character.